### PR TITLE
[sdk-java] fix: linting, catbuffer generation and tests

### DIFF
--- a/catbuffer-generators/generators/common/MakoEnumGenerator.py
+++ b/catbuffer-generators/generators/common/MakoEnumGenerator.py
@@ -25,7 +25,7 @@ class MakoEnumGenerator(MakoStaticClassGenerator):
             if 'layout' in entity_schema:
                 for attribute in entity_schema['layout']:
                     if attribute.get('disposition', None) == TypeDescriptorDisposition.Const.value and attribute.get(
-                            'type', None) == self.name:
+                            'type', None) == self.name and not type_descriptor.endswith('TransactionV1'):
                         enum_name = type_descriptor
                         enum_comment = self.helper.get_comment_from_name(enum_name)
                         enum_value = attribute['value']

--- a/catbuffer-generators/generators/java/templates/EmbeddedTransactionBuilderHelper.mako
+++ b/catbuffer-generators/generators/java/templates/EmbeddedTransactionBuilderHelper.mako
@@ -21,7 +21,7 @@ public class EmbeddedTransactionBuilderHelper {
         entityTypeVersion = next(iter([x for x in layout if x.get('name','') == 'version']),{}).get('value',0)
 %>\
     %if (entityTypeValue > 0 and 'Aggregate' not in name and 'Block' not in name and name.startswith('Embedded')):
-        if (headerBuilder.getType() == EntityTypeDto.${helper.create_enum_name(name[8:])} && headerBuilder.getVersion() == ${entityTypeVersion}) {
+        if (headerBuilder.getType().getValue() == ${entityTypeValue} && headerBuilder.getVersion() == ${entityTypeVersion}) {
             ${name[8:]}BodyBuilder bodyBuilder = ${name[8:]}BodyBuilder.loadFromBinary(stream);
             SequenceInputStream concatenate = new SequenceInputStream(
             new ByteArrayInputStream(headerBuilder.serialize()),

--- a/catbuffer-generators/generators/java/templates/TransactionBuilderHelper.mako
+++ b/catbuffer-generators/generators/java/templates/TransactionBuilderHelper.mako
@@ -21,7 +21,7 @@ public class TransactionBuilderHelper {
         entityTypeVersion = next(iter([x for x in layout if x.get('name','') == 'version']),{}).get('value',0)
 %>\
     %if (entityTypeValue > 0  and 'Aggregate' not in name and 'Block' not in name and not name.startswith('Embedded')):
-        if (headerBuilder.getType() == EntityTypeDto.${helper.create_enum_name(name)} && headerBuilder.getVersion() == ${entityTypeVersion}) {
+        if (headerBuilder.getType().getValue() == ${entityTypeValue} && headerBuilder.getVersion() == ${entityTypeVersion}) {
             ${name}BodyBuilder bodyBuilder = ${name}BodyBuilder.loadFromBinary(stream);
             SequenceInputStream concatenate = new SequenceInputStream(
             new ByteArrayInputStream(headerBuilder.serialize()),
@@ -29,7 +29,7 @@ public class TransactionBuilderHelper {
             return ${name}Builder.loadFromBinary(new DataInputStream(concatenate));
         }
     %elif (entityTypeValue > 0 and 'Block' not in name and not name.startswith('Embedded')):
-        if (headerBuilder.getType() == EntityTypeDto.${helper.create_enum_name(name)} && headerBuilder.getVersion() == ${entityTypeVersion}) {
+        if (headerBuilder.getType().getValue() == ${entityTypeValue} && headerBuilder.getVersion() == ${entityTypeVersion}) {
             AggregateTransactionBodyBuilder bodyBuilder = AggregateTransactionBodyBuilder.loadFromBinary(stream);
             SequenceInputStream concatenate = new SequenceInputStream(
             new ByteArrayInputStream(headerBuilder.serialize()),

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/BinarySerializationImpl.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/BinarySerializationImpl.java
@@ -176,113 +176,117 @@ public class BinarySerializationImpl implements BinarySerialization {
   /** Constructor */
   public BinarySerializationImpl() {
     {
-		TransactionSerializer<?> serializer = new TransferTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new TransferTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicSupplyChangeTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicSupplyChangeTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicDefinitionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicDefinitionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AccountKeyLinkTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AccountKeyLinkTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AccountMetadataTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AccountMetadataTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicMetadataTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicMetadataTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new NamespaceMetadataTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new NamespaceMetadataTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new NamespaceRegistrationTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new NamespaceRegistrationTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new SecretLockTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new SecretLockTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new SecretProofTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new SecretProofTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AddressAliasTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AddressAliasTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicAliasTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicAliasTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new HashLockTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new HashLockTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MultisigAccountModificationTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MultisigAccountModificationTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicAddressRestrictionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicAddressRestrictionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new MosaicGlobalRestrictionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new MosaicGlobalRestrictionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AccountMosaicRestrictionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AccountMosaicRestrictionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AccountOperationRestrictionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AccountOperationRestrictionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AccountAddressRestrictionTransactionSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new AccountAddressRestrictionTransactionSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new NodeKeyLinkTransactionBuilderSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new NodeKeyLinkTransactionBuilderSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new VotingKeyLinkTransactionBuilderSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new VotingKeyLinkTransactionBuilderSerializer();
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new VrfKeyLinkTransactionBuilderSerializer();
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer = new VrfKeyLinkTransactionBuilderSerializer();
+      register(serializer, serializer.getVersion());
+    }
 
-	// beginregion use same objects for OLD version (format has not changed)
-	{
-		TransactionSerializer<?> serializer = new AggregateTransactionSerializer(TransactionType.AGGREGATE_COMPLETE, this);
-		register(serializer, 1);
-	}
+    // beginregion use same objects for OLD version (format has not changed)
     {
-		TransactionSerializer<?> serializer = new AggregateTransactionSerializer(TransactionType.AGGREGATE_BONDED, this);
-		register(serializer, 1);
-	}
-	// endregion
+      TransactionSerializer<?> serializer =
+          new AggregateTransactionSerializer(TransactionType.AGGREGATE_COMPLETE, this);
+      register(serializer, 1);
+    }
+    {
+      TransactionSerializer<?> serializer =
+          new AggregateTransactionSerializer(TransactionType.AGGREGATE_BONDED, this);
+      register(serializer, 1);
+    }
+    // endregion
 
     {
-		TransactionSerializer<?> serializer = new AggregateTransactionSerializer(TransactionType.AGGREGATE_COMPLETE, this);
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer =
+          new AggregateTransactionSerializer(TransactionType.AGGREGATE_COMPLETE, this);
+      register(serializer, serializer.getVersion());
+    }
     {
-		TransactionSerializer<?> serializer = new AggregateTransactionSerializer(TransactionType.AGGREGATE_BONDED, this);
-		register(serializer, serializer.getVersion());
-	}
+      TransactionSerializer<?> serializer =
+          new AggregateTransactionSerializer(TransactionType.AGGREGATE_BONDED, this);
+      register(serializer, serializer.getVersion());
+    }
   }
 
   /** @param serializer the serializer to be registered. */

--- a/sdk-core/src/test/java/io/nem/symbol/core/crypto/MerkleHashBuilderTest.java
+++ b/sdk-core/src/test/java/io/nem/symbol/core/crypto/MerkleHashBuilderTest.java
@@ -17,107 +17,118 @@ package io.nem.symbol.core.crypto;
 
 import io.nem.symbol.core.utils.ConvertUtils;
 import io.nem.symbol.sdk.infrastructure.RandomUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Testing of {@link MerkleHashBuilder} */
 public class MerkleHashBuilderTest {
-	byte[] calculateMerkleHash(Stream<byte[]> hashes) {
-		MerkleHashBuilder builder = new MerkleHashBuilder();
-		hashes.forEach(embeddedHash -> builder.update(embeddedHash));
-		return builder.getRootHash();
-	}
+  byte[] calculateMerkleHash(Stream<byte[]> hashes) {
+    MerkleHashBuilder builder = new MerkleHashBuilder();
+    hashes.forEach(embeddedHash -> builder.update(embeddedHash));
+    return builder.getRootHash();
+  }
 
-	void assertMerkleHash(String expectedHash, String[] hashes) {
-		// Act:
-		byte[] calculatedHash = calculateMerkleHash(Stream.of(hashes).map(ConvertUtils::fromHexToBytes));
+  void assertMerkleHash(String expectedHash, String[] hashes) {
+    // Act:
+    byte[] calculatedHash =
+        calculateMerkleHash(Stream.of(hashes).map(ConvertUtils::fromHexToBytes));
 
-		// Assert:
-		Assertions.assertEquals(expectedHash, ConvertUtils.toHex(calculatedHash));
-	}
+    // Assert:
+    Assertions.assertEquals(expectedHash, ConvertUtils.toHex(calculatedHash));
+  }
 
-	@Test
-	public void testZero() {
-		this.assertMerkleHash("0000000000000000000000000000000000000000000000000000000000000000", new String[] {});
-	}
+  @Test
+  public void testZero() {
+    this.assertMerkleHash(
+        "0000000000000000000000000000000000000000000000000000000000000000", new String[] {});
+  }
 
-	@Test
-	public void testOne() {
-		String randomHash = ConvertUtils.toHex(RandomUtils.generateRandomBytes(32));
-		this.assertMerkleHash(randomHash, new String[] { randomHash });
-	}
+  @Test
+  public void testOne() {
+    String randomHash = ConvertUtils.toHex(RandomUtils.generateRandomBytes(32));
+    this.assertMerkleHash(randomHash, new String[] {randomHash});
+  }
 
-	@Test
-	public void testCanBuildBalancedTree() {
-		this.assertMerkleHash(
-				"7D853079F5F9EE30BDAE49C4956AF20CDF989647AFE971C069AC263DA1FFDF7E",
-				new String[] {
-						"36C8213162CDBC78767CF43D4E06DDBE0D3367B6CEAEAEB577A50E2052441BC8",
-						"8A316E48F35CDADD3F827663F7535E840289A16A43E7134B053A86773E474C28",
-						"6D80E71F00DFB73B358B772AD453AEB652AE347D3E098AE269005A88DA0B84A7",
-						"2AE2CA59B5BB29721BFB79FE113929B6E52891CAA29CBF562EBEDC46903FF681",
-						"421D6B68A6DF8BB1D5C9ACF7ED44515E77945D42A491BECE68DA009B551EE6CE",
-						"7A1711AF5C402CFEFF87F6DA4B9C738100A7AC3EDAD38D698DF36CA3FE883480",
-						"1E6516B2CC617E919FAE0CF8472BEB2BFF598F19C7A7A7DC260BC6715382822C",
-						"410330530D04A277A7C96C1E4F34184FDEB0FFDA63563EFD796C404D7A6E5A20" });
-	}
+  @Test
+  public void testCanBuildBalancedTree() {
+    this.assertMerkleHash(
+        "7D853079F5F9EE30BDAE49C4956AF20CDF989647AFE971C069AC263DA1FFDF7E",
+        new String[] {
+          "36C8213162CDBC78767CF43D4E06DDBE0D3367B6CEAEAEB577A50E2052441BC8",
+          "8A316E48F35CDADD3F827663F7535E840289A16A43E7134B053A86773E474C28",
+          "6D80E71F00DFB73B358B772AD453AEB652AE347D3E098AE269005A88DA0B84A7",
+          "2AE2CA59B5BB29721BFB79FE113929B6E52891CAA29CBF562EBEDC46903FF681",
+          "421D6B68A6DF8BB1D5C9ACF7ED44515E77945D42A491BECE68DA009B551EE6CE",
+          "7A1711AF5C402CFEFF87F6DA4B9C738100A7AC3EDAD38D698DF36CA3FE883480",
+          "1E6516B2CC617E919FAE0CF8472BEB2BFF598F19C7A7A7DC260BC6715382822C",
+          "410330530D04A277A7C96C1E4F34184FDEB0FFDA63563EFD796C404D7A6E5A20"
+        });
+  }
 
-	@Test
-	public void testCanBuildFromUnbalancedTree() {
-		this.assertMerkleHash(
-				"DEFB4BF7ACF2145500087A02C88F8D1FCF27B8DEF4E0FDABE09413D87A3F0D09",
-				new String[] {
-						"36C8213162CDBC78767CF43D4E06DDBE0D3367B6CEAEAEB577A50E2052441BC8",
-						"8A316E48F35CDADD3F827663F7535E840289A16A43E7134B053A86773E474C28",
-						"6D80E71F00DFB73B358B772AD453AEB652AE347D3E098AE269005A88DA0B84A7",
-						"2AE2CA59B5BB29721BFB79FE113929B6E52891CAA29CBF562EBEDC46903FF681",
-						"421D6B68A6DF8BB1D5C9ACF7ED44515E77945D42A491BECE68DA009B551EE6CE" });
-	}
+  @Test
+  public void testCanBuildFromUnbalancedTree() {
+    this.assertMerkleHash(
+        "DEFB4BF7ACF2145500087A02C88F8D1FCF27B8DEF4E0FDABE09413D87A3F0D09",
+        new String[] {
+          "36C8213162CDBC78767CF43D4E06DDBE0D3367B6CEAEAEB577A50E2052441BC8",
+          "8A316E48F35CDADD3F827663F7535E840289A16A43E7134B053A86773E474C28",
+          "6D80E71F00DFB73B358B772AD453AEB652AE347D3E098AE269005A88DA0B84A7",
+          "2AE2CA59B5BB29721BFB79FE113929B6E52891CAA29CBF562EBEDC46903FF681",
+          "421D6B68A6DF8BB1D5C9ACF7ED44515E77945D42A491BECE68DA009B551EE6CE"
+        });
+  }
 
-	@Test
-	public void testChangingSubHashOrderChangesMerkleHash() {
-		// Arrange:
-		ArrayList<byte[]> seed1 = new ArrayList<byte[]>();
-		for (int i = 0; i < 8; ++i)
-			seed1.add(RandomUtils.generateRandomBytes(32));
+  @Test
+  public void testChangingSubHashOrderChangesMerkleHash() {
+    // Arrange:
+    ArrayList<byte[]> seed1 = new ArrayList<byte[]>();
+    for (int i = 0; i < 8; ++i) seed1.add(RandomUtils.generateRandomBytes(32));
 
-		List<byte[]> seed2 = Arrays.asList(
-			seed1.get(0), seed1.get(1), seed1.get(2), seed1.get(5),
-			seed1.get(4), seed1.get(3), seed1.get(6), seed1.get(7)
-		);
+    List<byte[]> seed2 =
+        Arrays.asList(
+            seed1.get(0),
+            seed1.get(1),
+            seed1.get(2),
+            seed1.get(5),
+            seed1.get(4),
+            seed1.get(3),
+            seed1.get(6),
+            seed1.get(7));
 
-		// Act:
-		byte[] rootHash1 = this.calculateMerkleHash(seed1.stream());
-		byte[] rootHash2 = this.calculateMerkleHash(seed2.stream());
+    // Act:
+    byte[] rootHash1 = this.calculateMerkleHash(seed1.stream());
+    byte[] rootHash2 = this.calculateMerkleHash(seed2.stream());
 
-		// Assert:
-		Assertions.assertNotEquals(ConvertUtils.toHex(rootHash1), ConvertUtils.toHex(rootHash2));
-	}
+    // Assert:
+    Assertions.assertNotEquals(ConvertUtils.toHex(rootHash1), ConvertUtils.toHex(rootHash2));
+  }
 
-	@Test
-	public void testChangingSubHashChangesMerkleHash() {
-		// Arrange:
-		ArrayList<byte[]> seed1 = new ArrayList<byte[]>();
-		for (int i = 0; i < 8; ++i)
-			seed1.add(RandomUtils.generateRandomBytes(32));
+  @Test
+  public void testChangingSubHashChangesMerkleHash() {
+    // Arrange:
+    ArrayList<byte[]> seed1 = new ArrayList<byte[]>();
+    for (int i = 0; i < 8; ++i) seed1.add(RandomUtils.generateRandomBytes(32));
 
-		List<byte[]> seed2 = Arrays.asList(
-			seed1.get(0), seed1.get(1), seed1.get(2), seed1.get(3),
-			RandomUtils.generateRandomBytes(32), seed1.get(5), seed1.get(6), seed1.get(7)
-		);
+    List<byte[]> seed2 =
+        Arrays.asList(
+            seed1.get(0),
+            seed1.get(1),
+            seed1.get(2),
+            seed1.get(3),
+            RandomUtils.generateRandomBytes(32),
+            seed1.get(5),
+            seed1.get(6),
+            seed1.get(7));
 
-		// Act:
-		byte[] rootHash1 = this.calculateMerkleHash(seed1.stream());
-		byte[] rootHash2 = this.calculateMerkleHash(seed2.stream());
+    // Act:
+    byte[] rootHash1 = this.calculateMerkleHash(seed1.stream());
+    byte[] rootHash2 = this.calculateMerkleHash(seed2.stream());
 
-		// Assert:
-		Assertions.assertNotEquals(ConvertUtils.toHex(rootHash1), ConvertUtils.toHex(rootHash2));
-	}
+    // Assert:
+    Assertions.assertNotEquals(ConvertUtils.toHex(rootHash1), ConvertUtils.toHex(rootHash2));
+  }
 }

--- a/sdk-core/src/test/java/io/nem/symbol/sdk/infrastructure/BinarySerializationTest.java
+++ b/sdk-core/src/test/java/io/nem/symbol/sdk/infrastructure/BinarySerializationTest.java
@@ -50,7 +50,8 @@ class BinarySerializationTest {
   @Test
   void testAllTransactionAreHandled() {
     BinarySerializationImpl binarySerialization = new BinarySerializationImpl();
-    List<TransactionType> notHandledTransactionTypes = Arrays.stream(TransactionType.values())
+    List<TransactionType> notHandledTransactionTypes =
+        Arrays.stream(TransactionType.values())
             .filter(
                 t -> {
                   try {
@@ -63,11 +64,11 @@ class BinarySerializationTest {
                 })
             .collect(Collectors.toList());
 
-	if (null == binarySerialization.resolveSerializer(TransactionType.AGGREGATE_BONDED, 1))
-		notHandledTransactionTypes.add(TransactionType.AGGREGATE_BONDED);
+    if (null == binarySerialization.resolveSerializer(TransactionType.AGGREGATE_BONDED, 1))
+      notHandledTransactionTypes.add(TransactionType.AGGREGATE_BONDED);
 
-	if (null == binarySerialization.resolveSerializer(TransactionType.AGGREGATE_COMPLETE, 1))
-		notHandledTransactionTypes.add(TransactionType.AGGREGATE_BONDED);
+    if (null == binarySerialization.resolveSerializer(TransactionType.AGGREGATE_COMPLETE, 1))
+      notHandledTransactionTypes.add(TransactionType.AGGREGATE_BONDED);
 
     Assertions.assertTrue(
         notHandledTransactionTypes.isEmpty(),

--- a/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/mappers/AggregateTransactionV1Mapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/mappers/AggregateTransactionV1Mapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.nem.symbol.sdk.infrastructure.okhttp.mappers;
+
+import io.nem.symbol.sdk.infrastructure.TransactionMapper;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
+import io.nem.symbol.sdk.model.transaction.TransactionType;
+
+/** Aggregate transaction mapper. */
+class AggregateTransactionV1Mapper extends AggregateTransactionMapper {
+
+  public AggregateTransactionV1Mapper(
+      JsonHelper jsonHelper, TransactionType transactionType, TransactionMapper transactionMapper) {
+    super(jsonHelper, transactionType, transactionMapper);
+  }
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+}

--- a/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/mappers/GeneralTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/mappers/GeneralTransactionMapper.java
@@ -66,6 +66,9 @@ public class GeneralTransactionMapper implements TransactionMapper {
     register(new AccountKeyLinkTransactionMapper(jsonHelper));
     register(new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
     register(new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
+    register(new AggregateTransactionV1Mapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
+    register(
+        new AggregateTransactionV1Mapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
   }
 
   private void register(TransactionMapper mapper) {

--- a/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
@@ -79,7 +79,7 @@ public class OkHttpAggregateTransactionTest {
             .build();
 
     assertEquals(networkType, aggregateTx.getNetworkType());
-    assertEquals(1, (int) aggregateTx.getVersion());
+    assertEquals(2, (int) aggregateTx.getVersion());
     assertTrue(
         LocalDateTime.now().isBefore(aggregateTx.getDeadline().getLocalDateTime(epochAdjustment)));
     assertEquals(BigInteger.valueOf(0), aggregateTx.getMaxFee());

--- a/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/mappers/AggregateTransactionV1Mapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/mappers/AggregateTransactionV1Mapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.nem.symbol.sdk.infrastructure.vertx.mappers;
+
+import io.nem.symbol.sdk.infrastructure.TransactionMapper;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
+import io.nem.symbol.sdk.model.transaction.TransactionType;
+
+/** Aggregate transaction mapper. */
+class AggregateTransactionV1Mapper extends AggregateTransactionMapper {
+
+  public AggregateTransactionV1Mapper(
+      JsonHelper jsonHelper, TransactionType transactionType, TransactionMapper transactionMapper) {
+    super(jsonHelper, transactionType, transactionMapper);
+  }
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+}

--- a/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/mappers/GeneralTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/mappers/GeneralTransactionMapper.java
@@ -66,6 +66,9 @@ public class GeneralTransactionMapper implements TransactionMapper {
     register(new AccountKeyLinkTransactionMapper(jsonHelper));
     register(new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
     register(new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
+    register(new AggregateTransactionV1Mapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
+    register(
+        new AggregateTransactionV1Mapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
   }
 
   private void register(TransactionMapper mapper) {

--- a/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
@@ -81,7 +81,7 @@ public class VertxAggregateTransactionTest {
             .build();
 
     assertEquals(networkType, aggregateTx.getNetworkType());
-    assertEquals(1, (int) aggregateTx.getVersion());
+    assertEquals(2, (int) aggregateTx.getVersion());
     assertTrue(
         LocalDateTime.now().isBefore(aggregateTx.getDeadline().getLocalDateTime(epochAdjustment)));
     assertEquals(BigInteger.valueOf(0), aggregateTx.getMaxFee());


### PR DESCRIPTION
## What was the issue?
- linting failed for some classes
- EntityTypeDto had enums with the same int value (pairs: `AGGREGATE_COMPLETE_TRANSACTION` and `AGGREGATE_COMPLETE_V1_TRANSACTION` also  `AGGREGATE_BONDED_TRANSACTION` and `AGGREGATE_BONDED_V1_TRANSACTION`). That caused `TransactionBuilderHelper` to not work correctly (the type was resolved by int value and was always `AGGREGATE_COMPLETE_TRANSACTION` or `AGGREGATE_BONDED_TRANSACTION`). Because of that clients throw exception with message `Unknown error mapping transaction: UnsupportedOperationException: Unimplemented Transaction type AGGREGATE_COMPLETE version 1` when fetching V1 historical aggregates 
- `OkHttpAggregateTransactionTest` and `VertxAggregateTransactionTest` tests failed because there was no mapper for V1 transaction

## What's the fix?
- fixed linting
- removed V1 transaction types from EntityTypeDto (with duplicated type code values)
- change TransactionBuilderHelper and EmbeddedTransactionBuilderHelper generation to compare by value code instead enum
- fix the default version assertion in OkHttpAggregateTransactionTest and VertxAggregateTransactionTest
- add v1 mapper to GeneralTransactionMapper for okhttp and vertx