### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.2] - 1-Nov-2022
+| Package           | Version | Link                                                                          |
+|-------------------|---------|-------------------------------------------------------------------------------|
+| SDK OkHttp        | v1.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-okhttp-client          |
+| SDK Vertx         | v1.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-vertx-client           |
+| Catbuffer Library | v0.1.3  | https://repo.maven.apache.org/maven2/io/nem/catbuffer-java                    |
+| Client OkHttp     | v1.0.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-okhttp-gson-client |
+| Client Vertx      | v1.0.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-vertx-client/      |
+
+- **[BREAKING CHANGE]** The type of value field in `AccountMetadataTransaction`, `MosaicMetadataTransaction`, `NamespaceMetadataTransaction` classes changed from `String` to `byte[]`.
+- [Fix] Fixed incorrect Merkle hash calculation for aggregate transactions, make the tests match the ones in Catapult.
+- Bumped AggregateTransaction version to V2. Note that the ability to create or broadcast V1 aggregate transactions has been removed.
+- Upgrade Gradle version to v6.9.3
+- Upgrade Catbuffer to v0.1.3
+- Flatten structure and move git submodules: `catbuffer-generators`, `catbuffer-parser` and `catbuffer-schemas` to SDK repository (at correct version)
+
 ## [1.0.1] - 7-Apr-2021
 
 **Milestone**: Symbol Mainnet

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     vertxVersion = "3.5.0"
     rxjavaVersion = "2.1.7"
     junitVersion = "5.9.0"
-    catbufferVersion = "0.1.3-SNAPSHOT"
+    catbufferVersion = "0.1.3"
     restApiVersion = "1.0.0"
     jackson_version = "2.9.9"
     jackson_databind_version = "2.9.9"


### PR DESCRIPTION
Releasing v1.0.2

| Package           | Version | Link                                                                          |
|-------------------|---------|-------------------------------------------------------------------------------|
| SDK OkHttp        | v1.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-okhttp-client          |
| SDK Vertx         | v1.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-vertx-client           |
| Catbuffer Library | v0.1.3  | https://repo.maven.apache.org/maven2/io/nem/catbuffer-java                    |
| Client OkHttp     | v1.0.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-okhttp-gson-client |
| Client Vertx      | v1.0.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-vertx-client/      |

- **[BREAKING CHANGE]** The type of value field in `AccountMetadataTransaction`, `MosaicMetadataTransaction`, `NamespaceMetadataTransaction` classes changed from `String` to `byte[]`.
- [Fix] Fixed incorrect Merkle hash calculation for aggregate transactions, make the tests match the ones in Catapult.
- Bumped AggregateTransaction version to V2. Note that the ability to create or broadcast V1 aggregate transactions has been removed.
- Upgrade Gradle version to v6.9.3
- Upgrade Catbuffer to v0.1.3
- Flatten structure and move git submodules: `catbuffer-generators`, `catbuffer-parser` and `catbuffer-schemas` to SDK repository (at correct version)